### PR TITLE
Add guidance about culpability

### DIFF
--- a/app/views/16/pre-sentence-report/offences.html
+++ b/app/views/16/pre-sentence-report/offences.html
@@ -72,7 +72,8 @@
                 <div id="summary-of-offences-hint" class="govuk-hint">
                   Review current and pervious offences to identify any patterns of
                   offending. This could include repeated similar or escalating
-                  offences.<br/><br/>
+                  offences. Consider culpability when describing the offences.
+                  <br/><br/>
                   Discuss the offences relevant to this pre-sentence report
                   that should be discussed before the court.<br/><br/>
                   You may want to <a href="https://www.sentencingcouncil.org.uk/search " class="govuk-link" rel="noreferrer noopener" target="_blank">


### PR DESCRIPTION
Andy Mason told us that report writers should
consider culpability when writing about the
offences however the culpability section is after
this so we will need to test and see if this is
possible.